### PR TITLE
Add config to show toast when device is locked

### DIFF
--- a/Notificaciones/index.php
+++ b/Notificaciones/index.php
@@ -57,9 +57,13 @@ if (
     $fields = array(
       "message" => array(
         "token" => $device[0],
-        "notification" => $notification
+        "notification" => $notification,
+        "android" => array(
+          "priority" => "high"
+        )
       )
     );
+    
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);


### PR DESCRIPTION
Android configuration is needed to show the notification when device screen is locked.