### PR TITLE
Retrieve attachments from vehicles or pedestrians

### DIFF
--- a/model/AttachmentModel.php
+++ b/model/AttachmentModel.php
@@ -1,0 +1,91 @@
+<?php 
+    Class Attachment {
+        private $id;
+        private $tipoEvidencia;
+        private $idVehiculo;
+        private $idPeaton;
+        private $archivo;
+        private $fechaRegistro;
+        private $fechaActualizacion;
+        private $estatusRegistro;
+
+        public function __construct($id, $tipoEvidencia, $idVehiculo, $idPeaton, $archivo, $fechaRegistro, $fechaActualizacion, $estatusRegistro) {
+            $this->id = $id;
+            $this->tipoEvidencia = $tipoEvidencia;
+            $this->idVehiculo = $idVehiculo;
+            $this->idPeaton = $idPeaton;
+            $this->archivo = $archivo;
+            $this->fechaRegistro = $fechaRegistro;
+            $this->fechaActualizacion = $fechaActualizacion;
+            $this->estatusRegistro = $estatusRegistro;
+        }
+
+        public function getId() {
+            return $this->id;
+        }
+
+        public function getTipoEvidencia() {
+            return $this->tipoEvidencia;
+        }
+
+        public function getIdVehiculo() {
+            return $this->idVehiculo;
+        }
+
+        public function getIdPeaton() {
+            return $this->idPeaton;
+        }
+
+        public function getArchivo() {
+            return $this->archivo;
+        }
+
+        public function getFechaRegistro() {
+            return $this->fechaRegistro;
+        }
+
+        public function getFechaActualizacion() {
+            return $this->fechaActualizacion;
+        }
+
+        public function getEstatusRegistro() {
+            return $this->estatusRegistro;
+        }
+
+        public function setId($id) {
+            $this->id = $id;
+        }
+
+        public function setTipoEvidencia($tipoEvidencia) {
+            $this->tipoEvidencia = $tipoEvidencia;
+        }
+
+        public function setIdVehiculo($idVehiculo) {
+            $this->idVehiculo = $idVehiculo;
+        }
+
+        public function setIdPeaton($idPeaton) {
+            $this->idPeaton = $idPeaton;
+        }
+
+        public function setArchivo($archivo) {
+            $this->archivo = $archivo;
+        }
+
+        public function setFechaRegistro($fechaRegistro) {
+            $this->fechaRegistro = $fechaRegistro;
+        }
+
+        public function setFechaActualizacion($fechaActualizacion) {
+            $this->fechaActualizacion = $fechaActualizacion;
+        }
+
+        public function setEstatusRegistro($estatusRegistro) {
+            $this->estatusRegistro = $estatusRegistro;
+        }
+
+        public function toString() {
+            return "Attachment [id=" . $this->id . ", tipoEvidencia=" . $this->tipoEvidencia . ", idVehiculo=" . $this->idVehiculo . ", idPeaton=" . $this->idPeaton . ", archivo=" . $this->archivo . ", fechaRegistro=" . $this->fechaRegistro . ", fechaActualizacion=" . $this->fechaActualizacion . ", estatusRegistro=" . $this->estatusRegistro . "]";
+        }
+    }   
+?>

--- a/model/VehicleModel.php
+++ b/model/VehicleModel.php
@@ -11,6 +11,7 @@
         private $fechaRegistro;
         private $fechaActualizacion;
         private $estatusRegistro;
+        private $attachedFiles;
 
         public function __construct($id, $idVisita, $conductor, $marca, $modelo, $anio, $placas, $color, $fechaRegistro, $fechaActualizacion, $estatusRegistro) {
             $this->id = $id;
@@ -70,6 +71,10 @@
             return $this->estatusRegistro;
         }
 
+        public function getAttachedFiles() {
+            return $this->attachedFiles;
+        }
+
         public function setId($id) {
             $this->id = $id;
         }
@@ -114,8 +119,12 @@
             $this->estatusRegistro = $estatusRegistro;
         }
 
+        public function setAttachedFiles($attachedFiles) {
+            $this->attachedFiles = $attachedFiles;
+        }
+
         public function toString() {
-            return "id: ".$this->id.", idVisita: ".$this->idVisita.", conductor: ".$this->conductor.", marca: ".$this->marca.", modelo: ".$this->modelo.", anio: ".$this->anio.", placas: ".$this->placas.", color: ".$this->color.", fechaRegistro: ".$this->fechaRegistro.", fechaActualizacion: ".$this->fechaActualizacion.", estatusRegistro: ".$this->estatusRegistro;
+            return "id: ".$this->id.", idVisita: ".$this->idVisita.", conductor: ".$this->conductor.", marca: ".$this->marca.", modelo: ".$this->modelo.", anio: ".$this->anio.", placas: ".$this->placas.", color: ".$this->color.", fechaRegistro: ".$this->fechaRegistro.", fechaActualizacion: ".$this->fechaActualizacion.", estatusRegistro: ".$this->estatusRegistro . ", attachedFiles: " . $this->attachedFiles;
         }
     }
 

--- a/model/VisitaPeatonModel.php
+++ b/model/VisitaPeatonModel.php
@@ -6,6 +6,7 @@
         private $fechaRegistro;
         private $fechaActualizacion;
         private $estatusRegistro;
+        private $attachedFiles;
 
         public function __construct($id, $idVisita, $nombre, $fechaRegistro, $fechaActualizacion, $estatusRegistro) {
             $this->id = $id;
@@ -40,6 +41,10 @@
             return $this->estatusRegistro;
         }
 
+        public function getAttachedFiles() {
+            return $this->attachedFiles;
+        }
+
         public function setId($id) {
             $this->id = $id;
         }
@@ -62,6 +67,10 @@
 
         public function setEstatusRegistro($estatusRegistro) {
             $this->estatusRegistro = $estatusRegistro;
+        }
+
+        public function setAttachedFiles($attachedFiles) {
+            $this->attachedFiles = $attachedFiles;
         }
 
         public function toString() {

--- a/repository/VisitaRepository.php
+++ b/repository/VisitaRepository.php
@@ -4,6 +4,7 @@
         require_once $_SERVER['DOCUMENT_ROOT']."/model/VisitaPeatonModel.php";
         require_once $_SERVER['DOCUMENT_ROOT']."/model/response/VisitaResponse.php";
         require_once $_SERVER['DOCUMENT_ROOT']."/model/VehicleModel.php";
+        require_once $_SERVER['DOCUMENT_ROOT']."/model/AttachmentModel.php";
 
         Class VisitaRepository extends Connection {
             private $table = "visitas";
@@ -118,6 +119,23 @@
                         $pedestriansArray = array();
                         if($vehicles && $vehicles->num_rows > 0) {
                             while($row = $vehicles->fetch_array()) {
+                                $attachmentRaw = $this->getAttachmentByVehiclePedestrianId($row["id"]);
+                                $attachments = array();
+                                if($attachmentRaw && $attachmentRaw->num_rows > 0) {
+                                    while($rowAttachment = $attachmentRaw->fetch_array()) {
+                                        $attachment = new Attachment(
+                                            $rowAttachment["id"],
+                                            $rowAttachment["tipo_evidencia"],
+                                            $rowAttachment["id_vehiculo_peaton"],
+                                            0,
+                                            $rowAttachment["archivo"],
+                                            $rowAttachment["fecha_registro"],
+                                            $rowAttachment["fecha_actualizacion"],
+                                            $rowAttachment["estatus_registro"]
+                                        );
+                                        array_push($attachments, $attachment);
+                                    }
+                                }
                                 $vehicle = new Vehicle(
                                     $row["id"],
                                     $row["id_visita"],
@@ -131,11 +149,29 @@
                                     $row["fecha_actualizacion"],
                                     $row["estatus_registro"]
                                 );
+                                $vehicle->setAttachedFiles($attachments);
                                 array_push($vehiclesArray, $vehicle);
                             }
                         }
                         if($pedestrians && $pedestrians->num_rows > 0) {
                             while($row = $pedestrians->fetch_array()) {
+                                $attachmentRaw = $this->getAttachmentByVehiclePedestrianId($row["id"]);
+                                $attachments = array();
+                                if($attachmentRaw && $attachmentRaw->num_rows > 0) {
+                                    while($rowAttachment = $attachmentRaw->fetch_array()) {
+                                        $attachment = new Attachment(
+                                            $rowAttachment["id"],
+                                            $rowAttachment["tipo_evidencia"],
+                                            0,
+                                            $rowAttachment["id_vehiculo_peaton"],
+                                            $rowAttachment["archivo"],
+                                            $rowAttachment["fecha_registro"],
+                                            $rowAttachment["fecha_actualizacion"],
+                                            $rowAttachment["estatus_registro"]
+                                        );
+                                        array_push($attachments, $attachment);
+                                    }
+                                }
                                 $pedestrian = new VisitasPeaton(
                                     $row["id"],
                                     $row["id_visita"],
@@ -144,6 +180,7 @@
                                     $row["fecha_actualizacion"],
                                     $row["estatus_registro"]
                                 );
+                                $pedestrian->setAttachedFiles($attachments);
                                 array_push($pedestriansArray, $pedestrian);
                             }
                         }
@@ -384,6 +421,15 @@
             public function getPedestriansByVisit(int $idVisita) {
                 try {
                     $query = sprintf("SELECT * FROM `visitas_peatones` WHERE `id_visita` = %d AND `estatus_registro` = 1", $idVisita);
+                    return $this->execQuery($query);
+                } catch (\Throwable $th) {
+                    echo $th;
+                }
+            }
+
+            public function getAttachmentByVehiclePedestrianId(int $idVehicle) {
+                try {
+                    $query = sprintf("SELECT * FROM `visitas_evidencia` WHERE `id_vehiculo_peaton` = %d", $idVehicle);
                     return $this->execQuery($query);
                 } catch (\Throwable $th) {
                     echo $th;

--- a/service/VisitaService.php
+++ b/service/VisitaService.php
@@ -262,6 +262,19 @@
 
             $vehiclesArr = array();
             foreach($visitaResponse->getVehicles() as $vehicle) {
+                $attachments = array();
+                foreach($vehicle->getAttachedFiles() as $attachedFile) {
+                    array_push($attachments, array(
+                        "id" => $attachedFile->getId(),
+                        "tipoEvidencia" => $attachedFile->getTipoEvidencia(),
+                        "idVehiculo" => $attachedFile->getIdVehiculo(),
+                        "idPeaton" => $attachedFile->getIdPeaton(),
+                        "archivo" => $attachedFile->getArchivo(),
+                        "fechaRegistro" => $attachedFile->getFechaRegistro(),
+                        "fechaActualizacion" => $attachedFile->getFechaActualizacion(),
+                        "estatusRegistro" => $attachedFile->getEstatusRegistro(
+                        )));
+                }
                 $vehicleArr = array(
                     "id" => $vehicle->getId(),
                     "idVisita" => $vehicle->getIdVisita(),
@@ -273,19 +286,34 @@
                     "color" => $vehicle->getColor(),
                     "fechaRegistro" => $vehicle->getFechaRegistro(),
                     "fechaActualizacion" => $vehicle->getFechaActualizacion(),
-                    "estatusRegistro" => $vehicle->getEstatusRegistro()
+                    "estatusRegistro" => $vehicle->getEstatusRegistro(),
+                    "attachedFiles" => $attachments
                 );
                 array_push($vehiclesArr, $vehicleArr);
             }
             $pedestriansArr = array();
             foreach($visitaResponse->getPedestrians() as $pedestrian) {
+                $attachments = array();
+                foreach($pedestrian->getAttachedFiles() as $attachedFile) {
+                    array_push($attachments, array(
+                        "id" => $attachedFile->getId(),
+                        "tipoEvidencia" => $attachedFile->getTipoEvidencia(),
+                        "idVehiculo" => $attachedFile->getIdVehiculo(),
+                        "idPeaton" => $attachedFile->getIdPeaton(),
+                        "archivo" => $attachedFile->getArchivo(),
+                        "fechaRegistro" => $attachedFile->getFechaRegistro(),
+                        "fechaActualizacion" => $attachedFile->getFechaActualizacion(),
+                        "estatusRegistro" => $attachedFile->getEstatusRegistro(
+                        )));
+                }
                 $pedestrianArr = array(
                     "id" => $pedestrian->getId(),
                     "idVisita" => $pedestrian->getIdVisita(),
                     "nombre" => $pedestrian->getNombre(),
                     "fechaRegistro" => $pedestrian->getFechaRegistro(),
                     "fechaActualizacion" => $pedestrian->getFechaActualizacion(),
-                    "estatusRegistro" => $pedestrian->getEstatusRegistro()
+                    "estatusRegistro" => $pedestrian->getEstatusRegistro(),
+                    "attachedFiles" => $attachments
                 );
                 array_push($pedestriansArr, $pedestrianArr);
             }


### PR DESCRIPTION
- Model to represent the evidence attached and saved into the DB.
- Include all vehicles, pedestrians, and evidence attached when the visit is queried.